### PR TITLE
feat: set CONVEX_NON_INTERACTIVE for backend dev

### DIFF
--- a/services/backend/package.json
+++ b/services/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "convex dev",
+    "dev": "CONVEX_NON_INTERACTIVE=true convex dev",
     "deploy": "convex deploy",
     "migrate": "convex run migrations:runAll",
     "typecheck": "tsc --build",


### PR DESCRIPTION
## Summary
Sets the `CONVEX_NON_INTERACTIVE` environment variable when running the backend dev server via `pnpm dev` or `turbo run dev`.

## Changes Made
- Modified `services/backend/package.json`: Changed dev script from `"dev": "convex dev"` to `"dev": "CONVEX_NON_INTERACTIVE=true convex dev"`

This prevents interactive prompts from Convex during development.