### PR TITLE
feat: add @convex-dev/aggregate component to backend

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
 
   services/backend:
     dependencies:
+      '@convex-dev/aggregate':
+        specifier: ^0.2.1
+        version: 0.2.1(convex@1.34.1(react@19.2.3))
       '@convex-dev/migrations':
         specifier: ^0.3.3
         version: 0.3.3(convex@1.34.1(react@19.2.3))
@@ -394,6 +397,11 @@ packages:
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
+
+  '@convex-dev/aggregate@0.2.1':
+    resolution: {integrity: sha512-z8GeUC+cIZEgtMXecX6WTBQHNW4E2ioRsc5IkO8BWnCjgDOru/Mw8zXe9JPe35JkqDjlSVKuwxiQHKs/jaYAyA==}
+    peerDependencies:
+      convex: ^1.24.8
 
   '@convex-dev/eslint-plugin@1.2.2':
     resolution: {integrity: sha512-hLElzzSHuO83O/7PqaeFrMy8EOaDPMAUBNaqo7wkOzCsUCgA+tI9SXVSVLUozDGBBQjyXjAaPYRIBKoPeZbZKg==}
@@ -5481,6 +5489,10 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@convex-dev/aggregate@0.2.1(convex@1.34.1(react@19.2.3))':
+    dependencies:
+      convex: 1.34.1(react@19.2.3)
 
   '@convex-dev/eslint-plugin@1.2.2(convex@1.34.1(react@19.2.3))(eslint@9.26.0(jiti@2.4.2))(typescript@5.9.3)':
     dependencies:

--- a/services/backend/convex/convex.config.ts
+++ b/services/backend/convex/convex.config.ts
@@ -1,7 +1,9 @@
+import aggregate from '@convex-dev/aggregate/convex.config.js';
 import migrations from '@convex-dev/migrations/convex.config.js';
 import { defineApp } from 'convex/server';
 
 const app = defineApp();
+app.use(aggregate);
 app.use(migrations);
 
 export default app;

--- a/services/backend/package.json
+++ b/services/backend/package.json
@@ -15,6 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@convex-dev/aggregate": "^0.2.1",
     "@convex-dev/migrations": "^0.3.3",
     "convex": "^1.34.1",
     "convex-helpers": "^0.1.114",


### PR DESCRIPTION
## Summary
Adds the `@convex-dev/aggregate` Convex component to the backend service.

## Changes
- Installed `@convex-dev/aggregate` (^0.2.1) in `services/backend`
- Registered the aggregate component in `services/backend/convex/convex.config.ts`

## Testing
- Typecheck passes
- All tests pass