### PR TITLE
feat: update convex dev command with local backend version

### DIFF
--- a/services/backend/package.json
+++ b/services/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "CONVEX_NON_INTERACTIVE=true convex dev",
+    "dev": "CONVEX_NON_INTERACTIVE=true DOCUMENT_RETENTION_DELAY=1 INDEX_RETENTION_DELAY=1 RETENTION_DELETE_FREQUENCY=10 convex dev --local --local-backend-version precompiled-2026-04-07-9ad94d1",
     "deploy": "convex deploy",
     "migrate": "convex run migrations:runAll",
     "typecheck": "tsc --build",


### PR DESCRIPTION
## Summary
- Update the `dev` script in `services/backend/package.json` to use the precompiled Convex backend version
- Added environment variables for document/index retention delays to speed up local development

## Changes
- Changed dev command from `CONVEX_NON_INTERACTIVE=true convex dev` to `CONVEX_NON_INTERACTIVE=true DOCUMENT_RETENTION_DELAY=1 INDEX_RETENTION_DELAY=1 RETENTION_DELETE_FREQUENCY=10 convex dev --local --local-backend-version precompiled-2026-04-07-9ad94d1`