### PR TITLE
fix: move react-grab script from head to body

### DIFF
--- a/apps/webapp/src/app/layout.tsx
+++ b/apps/webapp/src/app/layout.tsx
@@ -60,14 +60,6 @@ export default function RootLayout({
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-touch-fullscreen" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-        {/* React Grab for development */}
-        {process.env.NODE_ENV === 'development' && (
-          <Script
-            src="//unpkg.com/react-grab/dist/index.global.js"
-            crossOrigin="anonymous"
-            strategy="afterInteractive"
-          />
-        )}
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <ConvexClientProvider>
@@ -85,6 +77,14 @@ export default function RootLayout({
           </ConvexQueryCacheProvider>
         </ConvexClientProvider>
         <Toaster />
+        {/* React Grab for development */}
+        {process.env.NODE_ENV === 'development' && (
+          <Script
+            src="//unpkg.com/react-grab/dist/index.global.js"
+            crossOrigin="anonymous"
+            strategy="afterInteractive"
+          />
+        )}
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

Move the react-grab Script component from inside  to inside .

## Problem

The  component should not be placed inside . When it is, Next.js's script-injection and hydration-reconciliation logic gets confused, causing hydration mismatches.

## Solution

Move the Script to the end of  where it properly renders as an inline element instead of conflicting with the head's metadata structure.