### PR TITLE
feat: add e2e testing with Playwright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ out/
 
 # Testing
 coverage/
+playwright-report/
+test-results/
 
 # Misc
 .env*.local

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
+    "e2e": "playwright test --config=tests/e2e/playwright.config.ts",
     "generate:icons": "bun run scripts/generate-icons.ts",
     "generate:icons:all": "bun run scripts/generate-icons.ts --favicon"
   },
@@ -54,6 +55,7 @@
   "devDependencies": {
     "@mdx-js/react": "^3.1.0",
     "@next/mdx": "16.2.3",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^6.9.1",
@@ -67,6 +69,7 @@
     "bun": "^1.3.2",
     "dotenv-cli": "^11.0.0",
     "jsdom": "^27.1.0",
+    "playwright": "^1.60.0",
     "png-to-ico": "^2.1.8",
     "remark-gfm": "^4.0.1",
     "sharp": "^0.34.1",

--- a/apps/webapp/tests/e2e/app.spec.ts
+++ b/apps/webapp/tests/e2e/app.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+
+import { HomePage } from './pages/home.page';
+
+test.describe('Home Page', () => {
+  let homePage: HomePage;
+
+  test.beforeEach(async ({ page }) => {
+    homePage = new HomePage(page);
+    await homePage.navigate();
+  });
+
+  test('should display the correct page title', async () => {
+    const title = await homePage.getTitle();
+    expect(title).toBe('Next Convex App');
+  });
+
+  test('should display the brand name in the navigation header', async () => {
+    await expect(homePage.brandLink).toBeVisible();
+    await expect(homePage.brandLink).toHaveText('Next Convex');
+  });
+
+  test('should display the main heading text', async () => {
+    await expect(homePage.heading).toBeVisible();
+    const headingText = await homePage.getHeadingText();
+    expect(headingText).toContain('Convex + Next Starter App');
+  });
+
+  test('should display the footer with app version', async () => {
+    await expect(homePage.footer).toBeVisible();
+    const footerText = (await homePage.footer.textContent()) ?? '';
+    expect(footerText).toMatch(/App Version:/);
+  });
+
+  test('should load the page successfully', async ({ page }) => {
+    const response = await page.goto('/');
+    expect(response?.status()).toBe(200);
+  });
+});

--- a/apps/webapp/tests/e2e/pages/base.page.ts
+++ b/apps/webapp/tests/e2e/pages/base.page.ts
@@ -1,0 +1,24 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Base Page Object Model providing common page interactions.
+ * All page objects should extend this class.
+ */
+export abstract class BasePage {
+  constructor(protected readonly page: Page) {}
+
+  /** Navigate to the given path relative to baseURL. */
+  async navigate(path = '/'): Promise<void> {
+    await this.page.goto(path);
+  }
+
+  /** Wait for the page to be fully loaded and ready. */
+  async waitForLoad(): Promise<void> {
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  /** Get the page title from the document. */
+  async getTitle(): Promise<string> {
+    return await this.page.title();
+  }
+}

--- a/apps/webapp/tests/e2e/pages/home.page.ts
+++ b/apps/webapp/tests/e2e/pages/home.page.ts
@@ -1,0 +1,48 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { BasePage } from './base.page';
+
+/**
+ * Page Object Model for the Home page ("/").
+ */
+export class HomePage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /** The main heading text on the home page. */
+  get heading(): Locator {
+    return this.page.getByText('Convex + Next Starter App');
+  }
+
+  /** The app logo/brand text in the navigation header. */
+  get brandLink(): Locator {
+    return this.page.getByRole('link', { name: 'Next Convex' });
+  }
+
+  /** The footer containing the app version. */
+  get footer(): Locator {
+    return this.page.locator('footer').filter({ hasText: 'App Version' });
+  }
+
+  /** The login button, visible when the user is not authenticated. */
+  get loginButton(): Locator {
+    return this.page.getByRole('link', { name: 'Login' });
+  }
+
+  /** Navigate to the home page and wait for it to load. */
+  override async navigate(path = '/'): Promise<void> {
+    await super.navigate(path);
+    await this.waitForLoad();
+  }
+
+  /** Get the main heading text content. */
+  async getHeadingText(): Promise<string> {
+    return (await this.heading.textContent()) ?? '';
+  }
+
+  /** Check if the login button is visible. */
+  async isLoginButtonVisible(): Promise<boolean> {
+    return await this.loginButton.isVisible();
+  }
+}

--- a/apps/webapp/tests/e2e/playwright.config.ts
+++ b/apps/webapp/tests/e2e/playwright.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for e2e tests.
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: '.',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    cwd: '../..', // webapp root relative to config location
+    env: {
+      PORT: '3000',
+    },
+  },
+});

--- a/apps/webapp/tests/e2e/playwright.config.ts
+++ b/apps/webapp/tests/e2e/playwright.config.ts
@@ -1,4 +1,33 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Reads the PORT value from the webapp's .env.local file.
+ * Falls back to 3000 if the file doesn't exist or PORT is not set.
+ */
+function getPort(): string {
+  const envPath = path.resolve(__dirname, '../../.env.local');
+  try {
+    const content = fs.readFileSync(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('#') || trimmed === '') continue;
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex === -1) continue;
+      const key = trimmed.slice(0, eqIndex).trim();
+      const value = trimmed.slice(eqIndex + 1).trim();
+      if (key === 'PORT') return value;
+    }
+  } catch {
+    // .env.local not found — use default
+  }
+  return '3000';
+}
+
+const port = getPort();
+const baseURL = `http://localhost:${port}`;
 
 /**
  * Playwright configuration for e2e tests.
@@ -19,7 +48,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -36,11 +65,11 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'pnpm dev',
-    url: 'http://localhost:3000',
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
     cwd: '../..', // webapp root relative to config location
     env: {
-      PORT: '3000',
+      PORT: port,
     },
   },
 });

--- a/apps/webapp/tests/e2e/tsconfig.json
+++ b/apps/webapp/tests/e2e/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["./**/*.ts"]
+}

--- a/apps/webapp/vitest.config.ts
+++ b/apps/webapp/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     setupFiles: ['./vitest.setup.ts'],
     globals: true,
     css: true,
+    exclude: ['tests/e2e/**', 'node_modules/**'],
   },
   resolve: {
     alias: {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format:fix": "prettier --write .",
     "typecheck": "turbo run typecheck",
     "find-deadcode": "knip",
+    "e2e": "turbo run e2e",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,7 +161,7 @@ importers:
         version: 3.6.1
       next:
         specifier: 16.2.3
-        version: 16.2.3(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.2.3(@babel/core@7.28.5)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -193,6 +193,9 @@ importers:
       '@next/mdx':
         specifier: 16.2.3
         version: 16.2.3(@mdx-js/loader@3.1.0(acorn@8.15.0))(@mdx-js/react@3.1.0(@types/react@19.2.7)(react@19.2.3))
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.5
@@ -232,6 +235,9 @@ importers:
       jsdom:
         specifier: ^27.1.0
         version: 27.1.0
+      playwright:
+        specifier: ^1.60.0
+        version: 1.60.0
       png-to-ico:
         specifier: ^2.1.8
         version: 2.1.8
@@ -1537,6 +1543,11 @@ packages:
     resolution: {integrity: sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -3751,6 +3762,11 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4723,6 +4739,16 @@ packages:
   pkce-challenge@5.0.0:
     resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
     engines: {node: '>=16.20.0'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   png-to-ico@2.1.8:
     resolution: {integrity: sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w==}
@@ -6600,6 +6626,10 @@ snapshots:
 
   '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
     optional: true
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -9107,6 +9137,9 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -10181,7 +10214,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@16.2.3(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.2.3(@babel/core@7.28.5)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
@@ -10200,6 +10233,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.3
       '@next/swc-win32-arm64-msvc': 16.2.3
       '@next/swc-win32-x64-msvc': 16.2.3
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -10396,6 +10430,14 @@ snapshots:
   pidtree@0.6.0: {}
 
   pkce-challenge@5.0.0: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   png-to-ico@2.1.8:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -29,6 +29,11 @@
     "dev": {
       "cache": false,
       "persistent": true
+    },
+    "e2e": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## Summary

Introduce end-to-end testing conventions using Playwright with TypeScript.

## Changes

- **Playwright integration**: Added `@playwright/test` and `playwright` as dev dependencies
- **Test structure**: All e2e files in `apps/webapp/tests/e2e/`
  - `playwright.config.ts` — Chromium browser, webServer auto-starts dev server, HTML reporter
  - `pages/base.page.ts` — Base Page Object Model with navigate, waitForLoad, getTitle
  - `pages/home.page.ts` — HomePage POM with locators for heading, nav brand, footer
  - `app.spec.ts` — 5 sample tests covering page title, brand, heading, footer, HTTP status
  - `tsconfig.json` — TypeScript support for IDE
- **Scripts**: 
  - `pnpm e2e` in webapp runs Playwright directly
  - `pnpm e2e` at root runs via `turbo run e2e` (builds deps first)
- **Vitest exclusion**: Excluded e2e tests from vitest runner
- **Gitignore**: Added `playwright-report/` and `test-results/`

## Running

```bash
# From root
pnpm e2e

# From webapp
cd apps/webapp && pnpm e2e
```

All 5 tests pass. Dev server starts and stops automatically via Playwright webServer config.