### PR TITLE
fix(layout): prevent nav/header overscroll

### DIFF
--- a/apps/webapp/src/app/app/admin/layout.tsx
+++ b/apps/webapp/src/app/app/admin/layout.tsx
@@ -31,7 +31,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
 
   return (
     <AdminGuard>
-      <div className="flex h-full">
+      <div className="flex h-full min-h-0">
         {_renderMobileHeader(openSidebar)}
         {_renderMobileSidebar(sidebarOpen, closeSidebar, handleBackdropKeyDown)}
         {_renderDesktopSidebar(closeSidebar)}
@@ -98,7 +98,7 @@ function _renderDesktopSidebar(closeSidebar: () => void) {
 
 function _renderMainContent(children: React.ReactNode) {
   return (
-    <div className="flex-1 overflow-auto">
+    <div className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain">
       <div className="pt-20 lg:pt-0 p-4 lg:p-6">{children}</div>
     </div>
   );

--- a/apps/webapp/src/app/globals.css
+++ b/apps/webapp/src/app/globals.css
@@ -225,6 +225,11 @@ input,
   * {
     @apply border-border outline-ring/50;
   }
+  html,
+  body {
+    height: 100%;
+    overflow: hidden;
+  }
   body {
     @apply bg-background text-foreground;
   }

--- a/apps/webapp/src/app/layout.tsx
+++ b/apps/webapp/src/app/layout.tsx
@@ -67,9 +67,11 @@ export default function RootLayout({
             <AppInfoProvider>
               <AuthProvider>
                 <ThemeProvider>
-                  <div className="flex flex-col h-screen overflow-hidden">
+                  <div className="flex h-dvh flex-col overflow-hidden">
                     <Navigation />
-                    <main className="flex-1 flex flex-col overflow-scroll">{children}</main>
+                    <main className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-y-contain">
+                      {children}
+                    </main>
                   </div>
                 </ThemeProvider>
               </AuthProvider>

--- a/apps/webapp/src/components/Navigation.tsx
+++ b/apps/webapp/src/components/Navigation.tsx
@@ -25,7 +25,7 @@ export function Navigation() {
   }, [authState]);
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <header className="z-50 w-full shrink-0 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="flex h-16 items-center px-4 sm:px-6">
         <div className="mr-6 flex">
           <Link


### PR DESCRIPTION
## Summary

- Keeps the main navigation fixed in the viewport shell; only page content scrolls
- Uses `min-h-0` flex children and `overscroll-y-contain` so scroll chaining does not move the header
- Applies the same contained-scroll pattern to the admin layout sidebar/content area
- Locks `html`/`body` overflow so the document does not scroll behind the app shell

## Context

Split from LLM provider work ([#52](https://github.com/conradkoh/next-convex-starter-app/pull/52)) — layout/overscroll fixes belong in this PR only.

## Test plan

- [x] `pnpm typecheck && pnpm test`
- [ ] Open a long page (e.g. admin or discussion) — header stays put while content scrolls
- [ ] On mobile, verify no rubber-band scroll moves the nav off-screen
- [ ] Admin layout: sidebar + main content scroll independently without overscroll bleed


Made with [Cursor](https://cursor.com)