### PR TITLE
Enforce ESLint rules against unsafe non-null unwrapping

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,8 @@ import globals from 'globals';
  * Key Rules:
  * - @typescript-eslint/no-unused-vars - Detect unused variables
  * - @typescript-eslint/no-explicit-any - Warn on explicit any types
+ * - @typescript-eslint/no-non-null-assertion - Disallow force-unwrapping with `!`
+ * - @typescript-eslint/no-non-null-asserted-optional-chain - Disallow `foo?.bar!`
  * - no-param-reassign - Prevent parameter reassignment
  * - @typescript-eslint/prefer-as-const - Prefer const assertions
  * - @typescript-eslint/default-param-last - Require default parameters to be last
@@ -94,6 +96,10 @@ export default [
 
       // Warn on explicit any types
       '@typescript-eslint/no-explicit-any': 'warn',
+
+      // Disallow force-unwrapping possibly null/undefined values (e.g. value!)
+      '@typescript-eslint/no-non-null-assertion': 'error',
+      '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
 
       // ============================================
       // Code Style Rules
@@ -235,6 +241,8 @@ export default [
     rules: {
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/no-non-null-asserted-optional-chain': 'off',
       '@typescript-eslint/prefer-as-const': 'off',
       '@typescript-eslint/default-param-last': 'off',
       '@typescript-eslint/no-inferrable-types': 'off',


### PR DESCRIPTION
## Summary
- Add `@typescript-eslint/no-non-null-assertion` to block force-unwrapping nullable values with `!`
- Add `@typescript-eslint/no-non-null-asserted-optional-chain` to block patterns like `foo?.bar!`
- Aligns with the repo's type-safety review criteria (no force unwrapping without null checks)

## Test plan
- [x] `pnpm lint` passes (no existing violations)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes

Made with [Cursor](https://cursor.com)