### PR TITLE
Set pnpm minimum release age for supply-chain protection

### DIFF
--- a/docs/developer/pnpm/minimum-release-age.md
+++ b/docs/developer/pnpm/minimum-release-age.md
@@ -1,0 +1,37 @@
+# pnpm minimum release age
+
+This workspace delays installing **newly published** npm package versions so compromised releases are more likely to be removed from the registry before they land in the tree.
+
+## Configuration
+
+Set in [`pnpm-workspace.yaml`](../../../pnpm-workspace.yaml):
+
+| Setting                   | Value  | Meaning                                                                               |
+| ------------------------- | ------ | ------------------------------------------------------------------------------------- |
+| `minimumReleaseAge`       | `1440` | Only install versions published at least **24 hours** ago                             |
+| `minimumReleaseAgeStrict` | `true` | Fail resolution if no version in range meets the age requirement (no silent fallback) |
+
+The delay applies to **all** dependencies, including transitive ones.
+
+## Day-to-day behavior
+
+- **Existing lockfile:** `pnpm install` with a committed `pnpm-lock.yaml` keeps current pinned versions; the setting mainly affects `pnpm add`, `pnpm update`, and lockfile refreshes.
+- **Fresh installs:** Resolution respects the minimum age when choosing versions.
+
+## Urgent or security patches
+
+When a fix must be installed before it is 24 hours old, add the package to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`:
+
+```yaml
+minimumReleaseAgeExclude:
+  - vulnerable-package@6.6.7
+```
+
+`pnpm audit --fix` can add entries here automatically for patched versions.
+
+To bypass temporarily (local only), use a one-off install with `minimumReleaseAge` set to `0` via CLI or env — prefer exclusions in the repo for audited exceptions.
+
+## References
+
+- [pnpm settings: minimumReleaseAge](https://pnpm.io/settings#minimumreleaseage)
+- [pnpm 11 release notes](https://pnpm.io/blog/releases/11.0) (defaults and supply-chain features)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,12 @@
 packages:
   - 'apps/*'
   - 'services/*'
+
+# Delay installing newly published versions (supply-chain protection).
+# See docs/developer/pnpm/minimum-release-age.md
+minimumReleaseAge: 1440 # minutes (24 hours)
+minimumReleaseAgeStrict: true
+
 allowBuilds:
   bun: true
   esbuild: true


### PR DESCRIPTION
## Summary

- Explicitly sets `minimumReleaseAge: 1440` (24 hours) in `pnpm-workspace.yaml` so newly published package versions are not installed until they are at least one day old
- Enables `minimumReleaseAgeStrict: true` so resolution fails if no version in range meets the age requirement (no silent fallback to a too-new version)
- Adds `docs/developer/pnpm/minimum-release-age.md` covering day-to-day behavior and `minimumReleaseAgeExclude` for urgent/security patches

Closes backlog item: security — set min age for pnpm installs.

## Context

pnpm 11 defaults to a 24-hour minimum release age, but the default is non-strict and easy to miss. This PR makes the policy explicit in the repo and documents how to handle exceptions.

## Test plan

- [x] `pnpm install` succeeds with existing lockfile
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [ ] Review docs and workspace settings after merge


Made with [Cursor](https://cursor.com)