### PR TITLE
fix(turbo): package task overrides for typecheck and build

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -36,6 +36,23 @@
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "cache": false
+    },
+    "@workspace/backend#typecheck": {
+      "dependsOn": ["^typecheck"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": ["dist/**"],
+      "cache": true
+    },
+    "@workspace/webapp#typecheck": {
+      "dependsOn": ["^typecheck"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*", "$TURBO_ROOT$/services/backend/**"],
+      "cache": true
+    },
+    "@workspace/webapp#build": {
+      "dependsOn": ["^typecheck", "typecheck"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": [".next/**", "!.next/cache/**"],
+      "cache": true
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds explicit `@workspace/backend#typecheck`, `@workspace/webapp#typecheck`, and `@workspace/webapp#build` overrides in `turbo.json`
- Package-specific tasks replace globals in Turbo — re-declares `dependsOn`, `outputs`, `inputs`, and `cache` so nothing is silently dropped
- Webapp typecheck now depends on `@workspace/backend#typecheck` (fixes TS6305 / missing `dist/` declarations)
- Webapp build restores `.next/**` outputs for Vercel remote cache

## Verification

- `pnpm turbo run typecheck --filter=@workspace/webapp --dry-run=json` → `webapp#typecheck` dependencies: `["@workspace/backend#typecheck"]`
- `pnpm typecheck` and `pnpm test` pass locally

## Test plan

- [ ] CI typecheck on webapp
- [ ] Vercel preview build restores `.next` from cache on rebuild

Made with [Cursor](https://cursor.com)