### PR TITLE
fix(webapp): disable Turbopack dev filesystem cache

### DIFF
--- a/apps/webapp/next.config.ts
+++ b/apps/webapp/next.config.ts
@@ -5,6 +5,10 @@ import type { NextConfig } from 'next';
 
 /** @type {import('next').NextConfig} */
 const nextConfig: NextConfig = {
+  experimental: {
+    // Disable persistent Turbopack disk cache in dev to avoid unbounded .next/cache growth
+    turbopackFileSystemCacheForDev: false,
+  },
   // Configure `pageExtensions` to include markdown and MDX files
   pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
   // Enable typed routes for compile-time type safety (moved from experimental in Next.js 16)


### PR DESCRIPTION
## Summary

- Disables `experimental.turbopackFileSystemCacheForDev` in `apps/webapp/next.config.ts`
- Addresses unbounded growth of `.next/cache` during local `next dev` (Turbopack persistent disk cache is enabled by default in Next.js 16.1+)

## Trade-off

Dev cold starts and HMR may be slightly slower without the persistent cache, but disk usage stays bounded. Existing cache can be cleared manually with `rm -rf apps/webapp/.next/cache` if needed.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] Run `pnpm dev` in webapp and confirm `.next/cache` does not grow unbounded across restarts


Made with [Cursor](https://cursor.com)