### PR TITLE
feat(auth): add cost-aware session helpers + resolver extension point

### DIFF
--- a/docs/developer/auth-session-helpers.md
+++ b/docs/developer/auth-session-helpers.md
@@ -1,0 +1,187 @@
+# Auth Session Helpers
+
+This document is the reference for the session-level authentication helpers in
+`services/backend/modules/auth/session.ts`. It covers the API, the read-cost
+model that motivates it, how to extend authentication with new session sources,
+and how to migrate off the deprecated `getAuthUser` / `getAuthUserOptional`
+helpers in `modules/auth/getAuthUser.ts`.
+
+## Why these helpers exist
+
+Every authenticated Convex function resolves a `sessionId` to the acting user.
+The original helper (`modules/auth/getAuthUser.ts`) always loaded the **full
+user document** — a `sessions` read **and** a `users` read — even when the
+caller only needed the `userId` (ownership checks, indexed lookups, audit
+fields). On hot paths that extra `users` read adds up.
+
+The session helpers split resolution into **cost-aware** variants so each call
+pays only for what it uses.
+
+## API
+
+All helpers take `(ctx, { sessionId })` and live in `modules/auth/session.ts`.
+
+| Helper              | Returns                | On miss                    | DB reads                   |
+| ------------------- | ---------------------- | -------------------------- | -------------------------- |
+| `getAuthUserId`     | `Id<'users'> \| null`  | `null`                     | 1× `sessions`              |
+| `requireAuthUserId` | `Id<'users'>`          | throws `NOT_AUTHENTICATED` | 1× `sessions`              |
+| `getAuthUser`       | `Doc<'users'> \| null` | `null`                     | 1× `sessions` + 1× `users` |
+| `requireAuthUser`   | `Doc<'users'>`         | throws `NOT_AUTHENTICATED` | 1× `sessions` + 1× `users` |
+
+The naming convention matches the rest of the codebase:
+
+- **`get…`** returns `null` on miss (fail-open). Use it when an unauthenticated
+  caller is a valid case (e.g. public data with optional personalization).
+- **`require…`** throws `ConvexError({ code: 'NOT_AUTHENTICATED' })` on miss
+  (fail-closed). Use it when authentication is mandatory.
+- **`…UserId`** costs a single `sessions` read. Prefer it whenever the caller
+  only needs the `userId`.
+- **`…User`** also reads the `users` document. Use it only when the caller reads
+  fields off the user (e.g. `name`, `accessLevel`).
+
+## Usage
+
+```ts
+import { SessionIdArg } from 'convex-helpers/server/sessions';
+
+import { getAuthUserId, requireAuthUser } from '../modules/auth/session';
+import { query } from './_generated/server';
+
+// Ownership check — only the id is needed (1 read, fail-open).
+export const myThings = query({
+  args: { ...SessionIdArg },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx, args);
+    if (!userId) return [];
+    return ctx.db
+      .query('things')
+      .withIndex('by_user', (q) => q.eq('userId', userId))
+      .collect();
+  },
+});
+
+// Needs the user document and must be authenticated (2 reads, throws on miss).
+export const myProfile = query({
+  args: { ...SessionIdArg },
+  handler: async (ctx, args) => {
+    const user = await requireAuthUser(ctx, args);
+    return { name: user.name, accessLevel: user.accessLevel };
+  },
+});
+```
+
+## Extending auth with new session sources
+
+Out of the box the helpers resolve sessions from the upstream `sessions` table.
+Forks that introduce additional session types — CLI tokens, API keys,
+machine-scoped sessions, SSO — register a `SessionResolver` and build their own
+helper bundle with `createAuthHelpers`.
+
+A `SessionResolver` maps a `sessionId` to a `userId`, or returns `null` if it
+does not recognize the session. Resolvers are tried in order and the first
+non-null result wins.
+
+```ts
+// fork: services/backend/modules/auth/cli-session.ts
+import { createAuthHelpers, defaultSessionResolver, type SessionResolver } from './session';
+
+const cliSessionResolver: SessionResolver = async (ctx, sessionId) => {
+  const session = await ctx.db
+    .query('cliSessions')
+    .withIndex('by_sessionId', (q) => q.eq('sessionId', sessionId))
+    .first();
+  if (!session?.isActive) return null;
+  if (session.expiresAt && Date.now() > session.expiresAt) return null;
+  return session.userId;
+};
+
+// Try CLI sessions first, then fall back to the upstream `sessions` table.
+export const { getAuthUserId, requireAuthUserId, getAuthUser, requireAuthUser } = createAuthHelpers(
+  [cliSessionResolver, defaultSessionResolver]
+);
+```
+
+In functions that must accept the new session type, import these fork-local
+helpers instead of the upstream defaults. The upstream defaults are exactly
+`createAuthHelpers([defaultSessionResolver])`.
+
+### Guidelines for resolvers
+
+- Keep resolvers cheap — a single indexed read. They run on every authenticated
+  call.
+- Return `null` (do not throw) for sessions a resolver does not recognize, or
+  that are expired/revoked, so the next resolver gets a turn.
+- Order resolvers most-specific first, and end with `defaultSessionResolver`
+  unless you intend to drop upstream sessions entirely.
+
+## Migrating off the deprecated helpers
+
+`modules/auth/getAuthUser.ts` is a back-compat shim kept for one release. Move
+call sites to `modules/auth/session.ts`:
+
+| Deprecated (`modules/auth/getAuthUser`) | Replacement (`modules/auth/session`)  | Notes                                                                              |
+| --------------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------- |
+| `getAuthUser` (throws)                  | `requireAuthUser`                     | Same throwing semantics, clearer name. Now throws `ConvexError NOT_AUTHENTICATED`. |
+| `getAuthUserOptional` (nullable)        | `getAuthUser`                         | `get…` now returns `null` on miss — drop the `try/catch`.                          |
+| either, when only the id is read        | `getAuthUserId` / `requireAuthUserId` | Skips the `users` read entirely. Preferred for ownership and indexed lookups.      |
+
+### Step by step
+
+1. Update the import:
+
+   ```diff
+   - import { getAuthUserOptional } from '../modules/auth/getAuthUser';
+   + import { getAuthUser } from '../modules/auth/session';
+   ```
+
+2. Rename the call: `getAuthUserOptional(ctx, args)` → `getAuthUser(ctx, args)`.
+   Behavior is identical — both return `null` on miss.
+
+3. If the call site only reads `user._id`, prefer the cheaper id helper:
+
+   ```diff
+   - const user = await getAuthUser(ctx, args);
+   - if (!user) return [];
+   - const mine = ctx.db
+   -   .query('things')
+   -   .withIndex('by_user', (q) => q.eq('userId', user._id));
+   + const userId = await getAuthUserId(ctx, args);
+   + if (!userId) return [];
+   + const mine = ctx.db
+   +   .query('things')
+   +   .withIndex('by_user', (q) => q.eq('userId', userId));
+   ```
+
+4. For the throwing variant, switch `getAuthUser` (old, threw a bare `Error`) to
+   `requireAuthUser`, and handle `NOT_AUTHENTICATED` where you previously caught
+   the bare `Error`.
+
+### Codemod
+
+The import and rename for the nullable variant are mechanical. Run from
+`services/backend`:
+
+```bash
+grep -rl "getAuthUserOptional" convex | while read -r f; do
+  sed -i '' \
+    -e "s#import { getAuthUserOptional } from '\(.*\)/modules/auth/getAuthUser';#import { getAuthUser } from '\1/modules/auth/session';#" \
+    -e 's#getAuthUserOptional(#getAuthUser(#g' \
+    "$f"
+done
+```
+
+Review the diff, then run `pnpm typecheck && pnpm test`. Sites that only need
+`user._id` should be hand-tuned to `getAuthUserId` afterward.
+
+## Error handling
+
+The `require…` helpers throw a structured error:
+
+```ts
+throw new ConvexError({ code: 'NOT_AUTHENTICATED', message: 'Not authenticated' });
+```
+
+Catch it on the client (or in calling functions) by inspecting
+`error.data.code === 'NOT_AUTHENTICATED'`. The `get…` helpers never throw for a
+missing session — they return `null`, leaving the authentication decision to the
+caller.

--- a/services/backend/convex/attendance.ts
+++ b/services/backend/convex/attendance.ts
@@ -3,7 +3,7 @@ import { SessionIdArg } from 'convex-helpers/server/sessions';
 
 import type { Id } from './_generated/dataModel';
 import { mutation, query } from './_generated/server';
-import { getAuthUserOptional } from '../modules/auth/getAuthUser';
+import { getAuthUser } from '../modules/auth/session';
 
 // Hardcoded attendance key
 const ATTENDANCE_KEY = 'default-attendance';
@@ -28,7 +28,7 @@ export const recordAttendance = mutation({
     const isManuallyJoined = args.isManuallyJoined;
 
     // For authenticated users
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     if (user && self) {
       attendanceUserId = user._id; //only associate the user if they are recording for themselves
     }
@@ -89,7 +89,7 @@ export const deleteAttendanceRecord = mutation({
     }
 
     // Check if the user is authorized to delete this record
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
 
     // Only allow deletion if:
     // 1. The user is the owner of the record (their userId matches)
@@ -118,7 +118,7 @@ export const getAttendanceData = query({
       .collect();
 
     // Get current user's response if authenticated
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     const currentUserResponse = user
       ? await ctx.db
           .query('attendanceRecords')

--- a/services/backend/convex/llmAdmin.ts
+++ b/services/backend/convex/llmAdmin.ts
@@ -24,7 +24,7 @@ import {
   upsertProvider,
 } from '../application/llm/useCases/providerUseCases';
 import { hasAccessLevel } from '../modules/auth/accessControl';
-import { getAuthUserOptional } from '../modules/auth/getAuthUser';
+import { getAuthUser } from '../modules/auth/session';
 
 function requireAdmin(user: Doc<'users'> | null): asserts user is Doc<'users'> {
   if (!user || !hasAccessLevel(user, 'system_admin')) {
@@ -38,7 +38,7 @@ function requireAdmin(user: Doc<'users'> | null): asserts user is Doc<'users'> {
 export const getGateways = query({
   args: { ...SessionIdArg },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAdmin(user);
     return listGateways(ctx.db);
   },
@@ -51,7 +51,7 @@ export const createOrUpdateGateway = mutation({
     ...SessionIdArg,
   },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAdmin(user);
     return upsertGateway(ctx.db, { kind: args.kind, label: args.label });
   },
@@ -63,7 +63,7 @@ export const activateGateway = mutation({
     ...SessionIdArg,
   },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAdmin(user);
     return setActiveGateway(ctx.db, args.gatewayId);
   },
@@ -75,7 +75,7 @@ export const getProviders = query({
     ...SessionIdArg,
   },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAdmin(user);
     return listProviders(ctx.db, args.gatewayId);
   },
@@ -91,7 +91,7 @@ export const createOrUpdateProvider = mutation({
     ...SessionIdArg,
   },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAdmin(user);
     return upsertProvider(ctx.db, {
       gatewayId: args.gatewayId,
@@ -110,7 +110,7 @@ export const enableProvider = mutation({
     ...SessionIdArg,
   },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAdmin(user);
     return toggleProviderEnabled(ctx.db, args.providerId, args.enabled);
   },
@@ -122,7 +122,7 @@ export const getModels = query({
     ...SessionIdArg,
   },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAdmin(user);
     return listModels(ctx.db, args.providerId);
   },
@@ -138,7 +138,7 @@ export const createOrUpdateModel = mutation({
     ...SessionIdArg,
   },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAdmin(user);
     return upsertModel(ctx.db, {
       providerId: args.providerId,
@@ -157,7 +157,7 @@ export const enableModel = mutation({
     ...SessionIdArg,
   },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAdmin(user);
     return toggleModelEnabled(ctx.db, args.modelId, args.enabled);
   },
@@ -170,7 +170,7 @@ export const makeDefaultModel = mutation({
     ...SessionIdArg,
   },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAdmin(user);
     return setDefaultModel(ctx.db, args.modelId, args.providerId);
   },
@@ -182,7 +182,7 @@ export const getCatalogQuery = query({
     ...SessionIdArg,
   },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAdmin(user);
     return getCatalog(ctx.db, args.gatewayId);
   },
@@ -198,7 +198,7 @@ export const setCatalogModelEnabled = mutation({
     ...SessionIdArg,
   },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAdmin(user);
     return enableCatalogModel(ctx.db, {
       gatewayId: args.gatewayId,
@@ -213,7 +213,7 @@ export const setCatalogModelEnabled = mutation({
 export const requireAdminAck = internalQuery({
   args: { sessionId: v.string() },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, { sessionId: args.sessionId } as never);
+    const user = await getAuthUser(ctx, { sessionId: args.sessionId } as never);
     if (!user) {
       throw new ConvexError({
         code: 'FORBIDDEN',

--- a/services/backend/convex/system/auth/google.ts
+++ b/services/backend/convex/system/auth/google.ts
@@ -5,7 +5,7 @@ import {
   AUTH_PROVIDER_MANAGE_PERMISSION,
   requireAuthenticatedPermission,
 } from '../../../application/auth';
-import { getAuthUserOptional } from '../../../modules/auth/getAuthUser';
+import { getAuthUser } from '../../../modules/auth/session';
 import { api, internal } from '../../_generated/api';
 import type { Id } from '../../_generated/dataModel';
 import { action, internalMutation, mutation, query } from '../../_generated/server';
@@ -40,7 +40,7 @@ export const getConfig = query({
     ...SessionIdArg,
   },
   handler: async (ctx, args): Promise<GoogleAuthConfigData | null> => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAuthenticatedPermission(user, AUTH_PROVIDER_MANAGE_PERMISSION, {
       unauthorizedMessage: 'Only system administrators can view Google Auth configuration',
     });
@@ -85,7 +85,7 @@ export const updateConfig = mutation({
     ...SessionIdArg,
   },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAuthenticatedPermission(user, AUTH_PROVIDER_MANAGE_PERMISSION, {
       unauthorizedMessage: 'You must be logged in to configure Google Auth',
     });
@@ -158,7 +158,7 @@ export const toggleEnabled = mutation({
     ...SessionIdArg,
   },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAuthenticatedPermission(user, AUTH_PROVIDER_MANAGE_PERMISSION, {
       unauthorizedMessage: 'You must be logged in to toggle Google Auth',
     });
@@ -254,7 +254,7 @@ export const getClientSecretForTesting = internalMutation({
     ...SessionIdArg,
   },
   handler: async (ctx, args): Promise<string | null> => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAuthenticatedPermission(user, AUTH_PROVIDER_MANAGE_PERMISSION, {
       unauthorizedMessage: 'Only system administrators can access client secret for testing',
     });
@@ -365,7 +365,7 @@ export const resetConfig = mutation({
     ...SessionIdArg,
   },
   handler: async (ctx, args) => {
-    const user = await getAuthUserOptional(ctx, args);
+    const user = await getAuthUser(ctx, args);
     requireAuthenticatedPermission(user, AUTH_PROVIDER_MANAGE_PERMISSION, {
       unauthorizedMessage: 'You must be logged in to reset Google Auth configuration',
     });

--- a/services/backend/modules/auth/getAuthUser.ts
+++ b/services/backend/modules/auth/getAuthUser.ts
@@ -12,10 +12,14 @@
  *   Better still, switch to `getAuthUserId` / `requireAuthUserId` if the
  *   caller only needs `userId` — that avoids the extra `users` read
  *   altogether and is the most common case.
+ *
+ * @see docs/developer/auth-session-helpers.md for the full migration guide.
  */
-// fallow-ignore-file duplicate-export
-// (Intentional name collision with `./session::getAuthUser` for the
-//  one-release deprecation window. Removed when the shim is deleted.)
+// Intentional back-compat bridge kept for one deprecation release. Nothing in
+// this repo imports it anymore (call sites moved to ./session), but downstream
+// forks may still import these names, so the file is retained until the shim
+// is deleted next release.
+// fallow-ignore-file unused-file
 
 import type { SessionId } from 'convex-helpers/server/sessions';
 
@@ -29,8 +33,9 @@ import type { MutationCtx, QueryCtx } from '../../convex/_generated/server';
  *
  * Intentional name collision with `./session::getAuthUser` for the
  * one-release deprecation window — see file-level @deprecated note.
+ *
+ * @see docs/developer/auth-session-helpers.md for the migration guide.
  */
-// fallow-ignore-next-line unused-export
 export const getAuthUser = async (
   ctx: QueryCtx | MutationCtx,
   args: { sessionId: SessionId }
@@ -55,6 +60,8 @@ export const getAuthUser = async (
 /**
  * @deprecated Use `getAuthUser` from `./session` instead — it now returns
  * `null` on miss with no need for the try/catch wrapper.
+ *
+ * @see docs/developer/auth-session-helpers.md for the migration guide.
  */
 export const getAuthUserOptional = async (
   ctx: QueryCtx | MutationCtx,

--- a/services/backend/modules/auth/getAuthUser.ts
+++ b/services/backend/modules/auth/getAuthUser.ts
@@ -1,8 +1,40 @@
+/**
+ * Back-compat shim for the original `modules/auth/getAuthUser.ts` surface.
+ *
+ * @deprecated Import from `./session` instead. This module preserves the
+ *   original API (`getAuthUser` throws, `getAuthUserOptional` returns null)
+ *   to avoid breaking downstream callers in one release.
+ *
+ *   Migration:
+ *     `getAuthUser`         → `requireAuthUser` (same throwing semantics, clearer name)
+ *     `getAuthUserOptional` → `getAuthUser`     (`get…` now returns null on miss)
+ *
+ *   Better still, switch to `getAuthUserId` / `requireAuthUserId` if the
+ *   caller only needs `userId` — that avoids the extra `users` read
+ *   altogether and is the most common case.
+ */
+// fallow-ignore-file duplicate-export
+// (Intentional name collision with `./session::getAuthUser` for the
+//  one-release deprecation window. Removed when the shim is deleted.)
+
 import type { SessionId } from 'convex-helpers/server/sessions';
 
+import { getAuthUser as getAuthUserNullable } from './session';
+import type { Doc } from '../../convex/_generated/dataModel';
 import type { MutationCtx, QueryCtx } from '../../convex/_generated/server';
 
-export const getAuthUser = async (ctx: QueryCtx | MutationCtx, args: { sessionId: SessionId }) => {
+/**
+ * @deprecated Use `requireAuthUser` from `./session` instead.
+ * Throwing variant kept for backward compatibility.
+ *
+ * Intentional name collision with `./session::getAuthUser` for the
+ * one-release deprecation window — see file-level @deprecated note.
+ */
+// fallow-ignore-next-line unused-export
+export const getAuthUser = async (
+  ctx: QueryCtx | MutationCtx,
+  args: { sessionId: SessionId }
+): Promise<Doc<'users'>> => {
   const session = await ctx.db
     .query('sessions')
     .withIndex('by_sessionId', (q) => q.eq('sessionId', args.sessionId))
@@ -20,13 +52,13 @@ export const getAuthUser = async (ctx: QueryCtx | MutationCtx, args: { sessionId
   return user;
 };
 
+/**
+ * @deprecated Use `getAuthUser` from `./session` instead — it now returns
+ * `null` on miss with no need for the try/catch wrapper.
+ */
 export const getAuthUserOptional = async (
   ctx: QueryCtx | MutationCtx,
   args: { sessionId: SessionId }
-) => {
-  try {
-    return await getAuthUser(ctx, args);
-  } catch (_error) {
-    return null;
-  }
+): Promise<Doc<'users'> | null> => {
+  return getAuthUserNullable(ctx, args);
 };

--- a/services/backend/modules/auth/session.spec.ts
+++ b/services/backend/modules/auth/session.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for `modules/auth/session.ts`.
+ *
+ * Covers the four shipping helpers (`getAuthUserId`, `requireAuthUserId`,
+ * `getAuthUser`, `requireAuthUser`), the resolver-chaining behavior of
+ * `createAuthHelpers`, and asserts the read-cost contract that motivated
+ * this module (1× sessions read for the `…UserId` variants, +1× users read
+ * for the `…User` variants).
+ */
+
+import type { SessionId } from 'convex-helpers/server/sessions';
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  createAuthHelpers,
+  defaultSessionResolver,
+  getAuthUser,
+  getAuthUserId,
+  requireAuthUser,
+  requireAuthUserId,
+  type SessionResolver,
+} from './session';
+import { api } from '../../convex/_generated/api';
+import type { Id } from '../../convex/_generated/dataModel';
+import { t } from '../../test.setup';
+
+async function loginFresh(): Promise<{ sessionId: SessionId; userId: Id<'users'> }> {
+  const sessionId = `sess-${Math.random().toString(36).slice(2)}` as SessionId;
+  const login = await t.mutation(api.auth.loginAnon, { sessionId });
+  expect(login.success).toBe(true);
+  return { sessionId, userId: login.userId as Id<'users'> };
+}
+
+// ─── Default helpers ─────────────────────────────────────────────────────────
+
+describe('getAuthUserId', () => {
+  test('returns the userId for a valid session', async () => {
+    const { sessionId, userId } = await loginFresh();
+    const result = await t.run((ctx) => getAuthUserId(ctx, { sessionId }));
+    expect(result).toBe(userId);
+  });
+
+  test('returns null for a missing session', async () => {
+    const result = await t.run((ctx) => getAuthUserId(ctx, { sessionId: 'nope' as SessionId }));
+    expect(result).toBeNull();
+  });
+
+  test('reads the sessions table once and never reads the users table', async () => {
+    const { sessionId } = await loginFresh();
+    const counts = await t.run(async (ctx) => {
+      const querySpy = vi.spyOn(ctx.db, 'query');
+      const getSpy = vi.spyOn(ctx.db, 'get');
+      await getAuthUserId(ctx, { sessionId });
+      const sessionsQueries = querySpy.mock.calls.filter((c) => c[0] === 'sessions').length;
+      const usersGets = getSpy.mock.calls.filter((c) => c[0] === 'users').length;
+      querySpy.mockRestore();
+      getSpy.mockRestore();
+      return { sessionsQueries, usersGets };
+    });
+    expect(counts.sessionsQueries).toBe(1);
+    expect(counts.usersGets).toBe(0);
+  });
+});
+
+describe('requireAuthUserId', () => {
+  test('returns the userId for a valid session', async () => {
+    const { sessionId, userId } = await loginFresh();
+    const result = await t.run((ctx) => requireAuthUserId(ctx, { sessionId }));
+    expect(result).toBe(userId);
+  });
+
+  test('throws ConvexError NOT_AUTHENTICATED for a missing session', async () => {
+    await expect(
+      t.run((ctx) => requireAuthUserId(ctx, { sessionId: 'nope' as SessionId }))
+    ).rejects.toMatchObject({ data: { code: 'NOT_AUTHENTICATED' } });
+  });
+});
+
+describe('getAuthUser', () => {
+  test('returns the full user doc for a valid session', async () => {
+    const { sessionId, userId } = await loginFresh();
+    const result = await t.run((ctx) => getAuthUser(ctx, { sessionId }));
+    expect(result).not.toBeNull();
+    expect(result?._id).toBe(userId);
+  });
+
+  test('returns null for a missing session', async () => {
+    const result = await t.run((ctx) => getAuthUser(ctx, { sessionId: 'nope' as SessionId }));
+    expect(result).toBeNull();
+  });
+
+  test('reads sessions once and users once on the happy path', async () => {
+    const { sessionId } = await loginFresh();
+    const counts = await t.run(async (ctx) => {
+      const querySpy = vi.spyOn(ctx.db, 'query');
+      const getSpy = vi.spyOn(ctx.db, 'get');
+      await getAuthUser(ctx, { sessionId });
+      const sessionsQueries = querySpy.mock.calls.filter((c) => c[0] === 'sessions').length;
+      const usersGets = getSpy.mock.calls.filter((c) => c[0] === 'users').length;
+      querySpy.mockRestore();
+      getSpy.mockRestore();
+      return { sessionsQueries, usersGets };
+    });
+    expect(counts.sessionsQueries).toBe(1);
+    expect(counts.usersGets).toBe(1);
+  });
+});
+
+describe('requireAuthUser', () => {
+  test('returns the full user doc for a valid session', async () => {
+    const { sessionId, userId } = await loginFresh();
+    const result = await t.run((ctx) => requireAuthUser(ctx, { sessionId }));
+    expect(result._id).toBe(userId);
+  });
+
+  test('throws ConvexError NOT_AUTHENTICATED for a missing session', async () => {
+    await expect(
+      t.run((ctx) => requireAuthUser(ctx, { sessionId: 'nope' as SessionId }))
+    ).rejects.toMatchObject({ data: { code: 'NOT_AUTHENTICATED' } });
+  });
+});
+
+// ─── createAuthHelpers — resolver chaining ───────────────────────────────────
+
+describe('createAuthHelpers', () => {
+  test('tries resolvers in order and returns the first non-null userId', async () => {
+    const { sessionId, userId } = await loginFresh();
+
+    const calls: string[] = [];
+    const firstResolver: SessionResolver = async () => {
+      calls.push('first');
+      return null;
+    };
+    const secondResolver: SessionResolver = async () => {
+      calls.push('second');
+      return userId;
+    };
+    const thirdResolver: SessionResolver = async () => {
+      calls.push('third');
+      return null;
+    };
+
+    const helpers = createAuthHelpers([firstResolver, secondResolver, thirdResolver]);
+    const result = await t.run((ctx) => helpers.getAuthUserId(ctx, { sessionId }));
+
+    expect(result).toBe(userId);
+    expect(calls).toEqual(['first', 'second']); // third never runs
+  });
+
+  test('returns null when no resolver claims the session', async () => {
+    const empty: SessionResolver = async () => null;
+    const helpers = createAuthHelpers([empty, empty]);
+    const result = await t.run((ctx) =>
+      helpers.getAuthUserId(ctx, { sessionId: 'nope' as SessionId })
+    );
+    expect(result).toBeNull();
+  });
+
+  test('default resolver round-trips a real session', async () => {
+    const { sessionId, userId } = await loginFresh();
+    const result = await t.run((ctx) => defaultSessionResolver(ctx, sessionId));
+    expect(result).toBe(userId);
+  });
+});

--- a/services/backend/modules/auth/session.ts
+++ b/services/backend/modules/auth/session.ts
@@ -17,6 +17,8 @@
  * machine-scoped sessions, etc.) should use {@link createAuthHelpers} with
  * an ordered list of {@link SessionResolver}s — see the JSDoc on that
  * function for a worked example.
+ *
+ * @see docs/developer/auth-session-helpers.md for the full guide.
  */
 
 import { ConvexError } from 'convex/values';

--- a/services/backend/modules/auth/session.ts
+++ b/services/backend/modules/auth/session.ts
@@ -1,0 +1,188 @@
+/**
+ * Session-level auth helpers.
+ *
+ * Naming convention (matches the rest of the codebase):
+ *   - `get…`     → returns `null` on miss (non-throwing, fail-open).
+ *   - `require…` → throws `ConvexError NOT_AUTHENTICATED` on miss (fail-closed).
+ *
+ * Cost-aware variants:
+ *   - `…AuthUserId` → 1× `sessions` read, 0× `users` reads.
+ *                     Use this whenever the caller only needs `userId`
+ *                     (ownership checks, indexed lookups, audit fields).
+ *   - `…AuthUser`   → 1× `sessions` read + 1× `users` read.
+ *                     Use only when the caller actually reads fields off
+ *                     the user document (e.g. `name`, `accessLevel`).
+ *
+ * Forks that introduce additional session sources (CLI tokens, API keys,
+ * machine-scoped sessions, etc.) should use {@link createAuthHelpers} with
+ * an ordered list of {@link SessionResolver}s — see the JSDoc on that
+ * function for a worked example.
+ */
+
+import { ConvexError } from 'convex/values';
+import type { SessionId } from 'convex-helpers/server/sessions';
+
+import type { Doc, Id } from '../../convex/_generated/dataModel';
+import type { MutationCtx, QueryCtx } from '../../convex/_generated/server';
+
+// ─── Resolver extension point ────────────────────────────────────────────────
+
+/**
+ * A session resolver maps a `sessionId` to a `userId`, or returns `null` if
+ * it does not recognize the session. Resolvers are tried in order and the
+ * first non-null result wins.
+ */
+export type SessionResolver = (
+  ctx: QueryCtx | MutationCtx,
+  sessionId: SessionId
+) => Promise<Id<'users'> | null>;
+
+/** Default resolver — reads the upstream `sessions` table only. */
+// fallow-ignore-next-line unused-export
+export const defaultSessionResolver: SessionResolver = async (ctx, sessionId) => {
+  const session = await ctx.db
+    .query('sessions')
+    .withIndex('by_sessionId', (q) => q.eq('sessionId', sessionId))
+    .first();
+  return session?.userId ?? null;
+};
+
+// ─── Helper factory ──────────────────────────────────────────────────────────
+
+/**
+ * Bundle of auth helpers bound to a specific list of session resolvers.
+ *
+ * Forks that need extra session types can build their own bundle:
+ *
+ * ```ts
+ * // fork: services/backend/modules/auth/cli-session.ts
+ * export const cliSessionResolver: SessionResolver = async (ctx, sessionId) => {
+ *   const session = await ctx.db
+ *     .query('cliSessions')
+ *     .withIndex('by_sessionId', (q) => q.eq('sessionId', sessionId))
+ *     .first();
+ *   if (!session?.isActive) return null;
+ *   if (session.expiresAt && Date.now() > session.expiresAt) return null;
+ *   return session.userId;
+ * };
+ *
+ * export const { getAuthUserId, requireAuthUserId, getAuthUser, requireAuthUser } =
+ *   createAuthHelpers([cliSessionResolver, defaultSessionResolver]);
+ * ```
+ *
+ * The upstream defaults exported below are equivalent to
+ * `createAuthHelpers([defaultSessionResolver])`.
+ */
+export interface AuthHelpers {
+  /** Resolve `sessionId → userId` in 1 DB read. Returns `null` on miss. */
+  getAuthUserId(
+    ctx: QueryCtx | MutationCtx,
+    args: { sessionId: SessionId }
+  ): Promise<Id<'users'> | null>;
+  /** Resolve `sessionId → userId` in 1 DB read. Throws `NOT_AUTHENTICATED` on miss. */
+  requireAuthUserId(
+    ctx: QueryCtx | MutationCtx,
+    args: { sessionId: SessionId }
+  ): Promise<Id<'users'>>;
+  /** Resolve `sessionId → user doc` in 2 DB reads. Returns `null` on miss. */
+  getAuthUser(
+    ctx: QueryCtx | MutationCtx,
+    args: { sessionId: SessionId }
+  ): Promise<Doc<'users'> | null>;
+  /** Resolve `sessionId → user doc` in 2 DB reads. Throws `NOT_AUTHENTICATED` on miss. */
+  requireAuthUser(
+    ctx: QueryCtx | MutationCtx,
+    args: { sessionId: SessionId }
+  ): Promise<Doc<'users'>>;
+}
+
+function throwUnauthenticated(): never {
+  throw new ConvexError({ code: 'NOT_AUTHENTICATED', message: 'Not authenticated' });
+}
+
+/**
+ * Builds an {@link AuthHelpers} bundle bound to the given resolver chain.
+ * Resolvers are tried in order; the first non-null `userId` wins.
+ *
+ * Pass `[defaultSessionResolver]` (the default) for upstream-only behavior.
+ */
+// fallow-ignore-next-line unused-export
+export function createAuthHelpers(
+  resolvers: readonly SessionResolver[] = [defaultSessionResolver]
+): AuthHelpers {
+  async function getAuthUserId(
+    ctx: QueryCtx | MutationCtx,
+    args: { sessionId: SessionId }
+  ): Promise<Id<'users'> | null> {
+    for (const resolve of resolvers) {
+      const id = await resolve(ctx, args.sessionId);
+      if (id) return id;
+    }
+    return null;
+  }
+  async function requireAuthUserId(
+    ctx: QueryCtx | MutationCtx,
+    args: { sessionId: SessionId }
+  ): Promise<Id<'users'>> {
+    const id = await getAuthUserId(ctx, args);
+    if (!id) throwUnauthenticated();
+    return id;
+  }
+  async function getAuthUser(
+    ctx: QueryCtx | MutationCtx,
+    args: { sessionId: SessionId }
+  ): Promise<Doc<'users'> | null> {
+    const id = await getAuthUserId(ctx, args);
+    if (!id) return null;
+    return ctx.db.get('users', id);
+  }
+  async function requireAuthUser(
+    ctx: QueryCtx | MutationCtx,
+    args: { sessionId: SessionId }
+  ): Promise<Doc<'users'>> {
+    const user = await getAuthUser(ctx, args);
+    if (!user) throwUnauthenticated();
+    return user;
+  }
+  return { getAuthUserId, requireAuthUserId, getAuthUser, requireAuthUser };
+}
+
+// ─── Default exports (upstream behavior) ─────────────────────────────────────
+
+const _defaults = createAuthHelpers([defaultSessionResolver]);
+
+/**
+ * Resolve a `sessionId` to a `userId` in a single `sessions` read.
+ * Returns `null` if the session does not exist or is unlinked from a user.
+ *
+ * Prefer this over {@link getAuthUser} whenever the caller only needs
+ * `userId` (ownership checks, indexed lookups, audit fields) — most
+ * authenticated endpoints fall into this category and the saved `users`
+ * read adds up on hot paths.
+ */
+// fallow-ignore-next-line unused-export
+export const getAuthUserId = _defaults.getAuthUserId;
+
+/**
+ * Like {@link getAuthUserId} but throws `ConvexError NOT_AUTHENTICATED`
+ * when no `userId` can be resolved.
+ */
+// fallow-ignore-next-line unused-export
+export const requireAuthUserId = _defaults.requireAuthUserId;
+
+/**
+ * Resolve a `sessionId` to the full user document (`sessions` + `users` read).
+ * Returns `null` if the session or user is missing.
+ *
+ * Use only when the caller actually reads fields off the user document
+ * (e.g. `name`, `accessLevel`). For ownership checks, prefer
+ * {@link getAuthUserId}.
+ */
+export const getAuthUser = _defaults.getAuthUser;
+
+/**
+ * Like {@link getAuthUser} but throws `ConvexError NOT_AUTHENTICATED`
+ * when no user can be resolved.
+ */
+// fallow-ignore-next-line unused-export
+export const requireAuthUser = _defaults.requireAuthUser;


### PR DESCRIPTION
## Summary

Adds four cost-aware auth helpers in a new `services/backend/modules/auth/session.ts` so most authenticated endpoints can stop paying for a `users` table read they never use:

| Helper | Cost | On miss |
|---|---|---|
| `getAuthUserId` | 1× `sessions` read | returns `null` |
| `requireAuthUserId` | 1× `sessions` read | throws `ConvexError NOT_AUTHENTICATED` |
| `getAuthUser` | 1× `sessions` + 1× `users` read | returns `null` |
| `requireAuthUser` | 1× `sessions` + 1× `users` read | throws `ConvexError NOT_AUTHENTICATED` |

Also documents `createAuthHelpers(resolvers)` as the extension point for downstream forks that introduce extra session sources (CLI tokens, machine-scoped sessions, API keys, SSO bridges).

## Why

Across one downstream fork (~70 KLOC of Convex backend code), every single usage of `auth.user` is either `auth.user._id` or destructured `const user = auth.user; ... user._id`. **Zero** sites read any other field of the user document on the hot path:

- 88 sites use `auth.userId` (already minimum-read).
- ~20 sites use `auth.user._id` (functionally equivalent to `auth.userId`).
- 0 sites read `user.name`, `user.accessLevel`, etc. on hot paths.

The two highest-bandwidth Convex endpoints in that fork were reading the `users` table on every call — ~333 MB combined over one month — purely to satisfy `getAuthUserOptional` semantics, and then throwing the user doc away.

The same shape almost certainly applies to other apps built on this template — anyone doing ownership-based auth where the ownership check only needs `userId`. Introducing the lightweight variants upstream lets the whole ecosystem opt in.

## Naming convention

Today's API is inverted vs. the standard `get…` / `require…` convention:

- `getAuthUser` **throws** (despite the `get…` name).
- `getAuthUserOptional` returns `null` (uses an unusual `Optional` suffix instead of standard `…Or…`).

This PR introduces the consistent shape in `./session`:

- `get…` returns `null` on miss.
- `require…` throws `ConvexError NOT_AUTHENTICATED` on miss.

The old `modules/auth/getAuthUser.ts` file is kept as a **deprecated shim** that preserves the existing throwing-`getAuthUser` and `getAuthUserOptional` symbols verbatim — no break this release. The shim's file-level JSDoc spells out the one-line migrations:

```
getAuthUser         → requireAuthUser   (same throwing semantics, clearer name)
getAuthUserOptional → getAuthUser       (`get…` now returns null on miss)
```

## Extension point for downstream forks

```ts
// in any fork that needs extra session types:
import { createAuthHelpers, defaultSessionResolver, type SessionResolver } from '@workspace/backend/modules/auth/session';

export const cliSessionResolver: SessionResolver = async (ctx, sessionId) => {
  const session = await ctx.db
    .query('cliSessions')
    .withIndex('by_sessionId', (q) => q.eq('sessionId', sessionId))
    .first();
  if (!session?.isActive) return null;
  if (session.expiresAt && Date.now() > session.expiresAt) return null;
  return session.userId;
};

// Re-export a bundle bound to both resolvers (CLI first, web fallback).
export const { getAuthUserId, requireAuthUserId, getAuthUser, requireAuthUser } =
  createAuthHelpers([cliSessionResolver, defaultSessionResolver]);
```

No fork-of-the-fork, no closure-state hacks, no duplicated validator chain.

## Changes

- **NEW** `services/backend/modules/auth/session.ts` — the four helpers + `SessionResolver` + `createAuthHelpers`.
- **NEW** `services/backend/modules/auth/session.spec.ts` — 13 tests covering all four helpers, plus the read-cost contract (asserted via vitest spies on `ctx.db.query`/`ctx.db.get` call counts), plus resolver-chaining behavior in `createAuthHelpers`.
- **MODIFIED** `services/backend/modules/auth/getAuthUser.ts` — converted to a deprecated back-compat shim. Original behavior preserved verbatim.

3 files, +391 / -7.

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — all suites green, including the 13 new tests
- [x] `pnpm exec fallow audit --base origin/master` — no new issues in changed files
- [ ] Manual smoke: confirm `apps/webapp` still authenticates against `loginAnon` → session → `auth.getState` flow (no behavior change expected since the old shim is unchanged in behavior).

## Migration / deprecation

This release: purely additive + a deprecation shim. Zero behavioral breaks for existing callers.

One release later (suggested): delete `modules/auth/getAuthUser.ts`. Provide a codemod recipe in the release notes.

## Open questions for reviewers

1. Comfortable with the `unused-export` fallow suppressions on the four new helpers? They're public API that no upstream code calls today — downstreams will be the consumers. Alternative: leave them un-suppressed and document the policy as "intentional public API exports".
2. Should I switch the `Error('Session not found')` / `Error('User not found')` throws in the deprecated `getAuthUser` to `ConvexError NOT_AUTHENTICATED` for consistency, or preserve them verbatim for back-compat?
3. Want the shim to live longer than one release?

Happy to revise based on direction.