### PR TITLE
fix(theme): hoist theme init script to layout, fix SSR hydration mismatch

### DIFF
--- a/apps/webapp/src/app/layout.tsx
+++ b/apps/webapp/src/app/layout.tsx
@@ -9,7 +9,7 @@ import { Navigation } from '@/components/Navigation';
 import { Toaster } from '@/components/ui/sonner';
 import { AppInfoProvider } from '@/modules/app/AppInfoProvider';
 import { AuthProvider } from '@/modules/auth/AuthProvider';
-import { ThemeProvider } from '@/modules/theme/ThemeProvider';
+import { ThemeProvider, themeScript } from '@/modules/theme/ThemeProvider';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -60,6 +60,9 @@ export default function RootLayout({
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-touch-fullscreen" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+        <Script id="theme-init" strategy="beforeInteractive">
+          {themeScript}
+        </Script>
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <ConvexClientProvider>

--- a/apps/webapp/src/modules/theme/ThemeProvider.tsx
+++ b/apps/webapp/src/modules/theme/ThemeProvider.tsx
@@ -30,7 +30,8 @@ export function useTheme() {
 }
 
 // Script to prevent flash of incorrect theme
-const themeScript = `
+// Exported so layout.tsx can inject it via next/script before hydration
+export const themeScript = `
 (() => {
   window.__theme = {
     value: localStorage.getItem('theme') || 'system',
@@ -93,12 +94,8 @@ const themeScript = `
 `;
 
 export function ThemeProvider({ children, targetSelector }: ThemeProviderProps) {
-  // Custom attribute to use for theme application
   const attribute = targetSelector ? 'data-theme' : 'class';
-  const [mounted] = useState(() => typeof window !== 'undefined');
-  const [theme, _setTheme] = useState<Theme | null>(() =>
-    typeof window !== 'undefined' ? window.__theme.value : null
-  );
+  const [theme, _setTheme] = useState<Theme | null>(null);
   const setTheme = useCallback((theme: Theme) => {
     _setTheme(theme);
     window.__theme.setTheme(theme);
@@ -106,32 +103,20 @@ export function ThemeProvider({ children, targetSelector }: ThemeProviderProps) 
 
   // We need to use this component pattern for hydration safety
   return (
-    <>
-      {/* Inject script to handle theme before React hydration */}
-      {}
-      <script dangerouslySetInnerHTML={{ __html: themeScript }} suppressHydrationWarning />
-
-      {mounted ? (
-        <ThemeContext.Provider value={{ theme, setTheme }}>
-          <NextThemesProvider
-            attribute={attribute}
-            defaultTheme="system"
-            enableSystem
-            themes={['light', 'dark']}
-            enableColorScheme
-            storageKey="theme"
-            // If a target selector is provided, use it as the element to apply theme to
-            {...(targetSelector && { selector: targetSelector })}
-          >
-            {children}
-          </NextThemesProvider>
-        </ThemeContext.Provider>
-      ) : (
-        // During SSR and before hydration, just render children
-        // The script above will handle theme application
-        children
-      )}
-    </>
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      <NextThemesProvider
+        attribute={attribute}
+        defaultTheme="system"
+        enableSystem
+        themes={['light', 'dark']}
+        enableColorScheme
+        storageKey="theme"
+        // If a target selector is provided, use it as the element to apply theme to
+        {...(targetSelector && { selector: targetSelector })}
+      >
+        {children}
+      </NextThemesProvider>
+    </ThemeContext.Provider>
   );
 }
 


### PR DESCRIPTION
## Summary
- Move the theme init script from an inline `<script>` inside `ThemeProvider` to `next/script` with `strategy="beforeInteractive"` in `layout.tsx`.
- Remove the `mounted` gate in `ThemeProvider` so server and client render the same tree (fixes hydration mismatch).

## Test plan
- [ ] `pnpm dev` and confirm no "Encountered a script tag" warning.
- [ ] Confirm no hydration mismatch error in browser console on first load.
- [ ] Theme toggles (light/dark/system) still apply correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)