### PR TITLE
Add Cursor model-pin rule

### DIFF
--- a/.cursor/rules/model-pin.mdc
+++ b/.cursor/rules/model-pin.mdc
@@ -1,0 +1,4 @@
+---
+alwaysApply: true
+model: composer-2.5[fast=false]
+---


### PR DESCRIPTION
Adds `.cursor/rules/model-pin.mdc` to pin Cursor to the `composer-2.5[fast=false]` model.