### PR TITLE
Revert Cursor model-pin rule

### DIFF
--- a/.cursor/rules/model-pin.mdc
+++ b/.cursor/rules/model-pin.mdc
@@ -1,4 +1,0 @@
----
-alwaysApply: true
-model: composer-2.5[fast=false]
----


### PR DESCRIPTION
Reverts #67 — removes `.cursor/rules/model-pin.mdc`.